### PR TITLE
Updating guzzlehttp to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle":"~6"
+        "guzzlehttp/guzzle":"^7"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
This will be used for new Laravel versions.